### PR TITLE
Disable plugin after declining first time configuration

### DIFF
--- a/WinHelloUnlock/WinHelloUnlockExt.cs
+++ b/WinHelloUnlock/WinHelloUnlockExt.cs
@@ -121,7 +121,20 @@ namespace WinHelloUnlock
 
                     // In case he/she wants, create the credentials
                     if (yesOrNo)
+                    {
                         await UWPLibrary.CreateHelloData(dbName);
+                    }
+                    else
+                    {
+                        // user do not want to configure plugin, so disable it for next time
+                        e.Database.CustomData.Set(ProductName, "false");
+                        e.Database.Modified = true;
+                        enablePlugin = false;
+
+                        // Try to save the database
+                        try { e.Database.Save(null); }
+                        catch { }
+                    }
                 }
             }
 

--- a/WinHelloUnlock/WinHelloUnlockExt.cs
+++ b/WinHelloUnlock/WinHelloUnlockExt.cs
@@ -83,59 +83,46 @@ namespace WinHelloUnlock
 		/// <param name="e"></param>
         private async void FileOpenedHandler(object sender, FileOpenedEventArgs e)
         {
-            var ioInfo = e.Database.IOConnectionInfo;
-            if (e.Database.CustomData.Get(ProductName) == null) // If there is no CustomData in this database
-            {
-                // Create CustomData to save global setting to enable or disable the plugin
-                e.Database.CustomData.Set(ProductName, "true");
-                e.Database.Modified = true;
-                
-                // Try to save the database
-                try { e.Database.Save(null); }
-                catch { }
-            }
+            database = e.Database;
+            var ioInfo = database.IOConnectionInfo;
 
             // Global settings to be used in the Options Panel
             dbName = Library.CharChange(ioInfo.Path);
-            database = e.Database;
             UWPLibrary.ck = database.MasterKey;
-            if (e.Database.CustomData.Get(ProductName + "AT") == "true") LockAfterAutoType = true;
-            else LockAfterAutoType = false;
 
-            if (e.Database.CustomData.Get(ProductName) == "true") enablePlugin = true;
-            if (e.Database.CustomData.Get(ProductName) == "false") // if plugin is disabled for the database
+            enablePlugin = database.CustomData.Get(ProductName) == "true" || database.CustomData.Get(ProductName) == null;
+            LockAfterAutoType = database.CustomData.Get(ProductName + "AT") == "true";
+
+            if (!enablePlugin) // if plugin is explicitely disabled for the database
             {
-                enablePlugin = false;
                 return; // Don't do anything else
             }
 
-            if (await UWPLibrary.FirstTime(dbName)) // If the database has no credentials saved
+            if (await UWPLibrary.IsHelloAvailable() && await UWPLibrary.FirstTime(dbName)) // If the database has no credentials saved
             {
-                bool isHelloAvailable = await UWPLibrary.IsHelloAvailable();
+                // Ask the user if he/she wants to configure the plugin
+                bool yesOrNo = MessageService.AskYesNo("Do You want to set " +
+                WinHelloUnlockExt.ProductName + " for " + dbName + " now?", WinHelloUnlockExt.ShortProductName, true);
 
-                if (isHelloAvailable)
+                // In case he/she wants, create the credentials
+                if (yesOrNo)
                 {
-                    // Ask the user if he/she wants to configure the plugin
-                    bool yesOrNo = MessageService.AskYesNo("Do You want to set " +
-                    WinHelloUnlockExt.ProductName + " for " + dbName + " now?", WinHelloUnlockExt.ShortProductName, true);
-
-                    // In case he/she wants, create the credentials
-                    if (yesOrNo)
-                    {
-                        await UWPLibrary.CreateHelloData(dbName);
-                    }
-                    else
-                    {
-                        // user do not want to configure plugin, so disable it for next time
-                        e.Database.CustomData.Set(ProductName, "false");
-                        e.Database.Modified = true;
-                        enablePlugin = false;
-
-                        // Try to save the database
-                        try { e.Database.Save(null); }
-                        catch { }
-                    }
+                    await UWPLibrary.CreateHelloData(dbName);
+                    // Create CustomData to save global setting to enable the plugin
+                    database.CustomData.Set(ProductName, "true");
                 }
+                else
+                {
+                    // Create CustomData to save global setting to disable the plugin
+                    database.CustomData.Set(ProductName, "false");
+                    enablePlugin = false;
+                }
+
+                database.Modified = true;
+
+                // Try to save the database
+                try { database.Save(null); }
+                catch { }
             }
 
             // Set global settings back to default


### PR DESCRIPTION
Hi @Angelelz,

this PR will finally disable the plugin in case the user declines the first time configuration messagebox.
Currently, the plugin will always ask the user to configure windows hello after opening the database, althougth the user declined this choice in the past. The only way to prevent the initialization dialog is to go to the options page and disable the plugin integration with the checkbox manually.

My first commit contains the quick and dirty fix. But since I copied some code I tried to refactor the method a little bit to increase readability in the second commit. Let me know if you have questions about it 😃 